### PR TITLE
Fix query invalidation with user id

### DIFF
--- a/src/hooks/useRefuelings.tsx
+++ b/src/hooks/useRefuelings.tsx
@@ -51,7 +51,7 @@ export const useRefuelings = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['refuelings'] });
+      queryClient.invalidateQueries({ queryKey: ['refuelings', user?.id] });
       toast({
         title: "Abastecimento registrado!",
         description: "Seu abastecimento foi salvo com sucesso.",
@@ -79,7 +79,7 @@ export const useRefuelings = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['refuelings'] });
+      queryClient.invalidateQueries({ queryKey: ['refuelings', user?.id] });
       toast({
         title: "Abastecimento atualizado!",
         description: "As informações foram salvas com sucesso.",
@@ -104,7 +104,7 @@ export const useRefuelings = () => {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['refuelings'] });
+      queryClient.invalidateQueries({ queryKey: ['refuelings', user?.id] });
       toast({
         title: "Abastecimento removido!",
         description: "O registro foi excluído com sucesso.",

--- a/src/hooks/useVehicleUsage.tsx
+++ b/src/hooks/useVehicleUsage.tsx
@@ -106,7 +106,7 @@ export const useVehicleUsage = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicle-usage'] });
+      queryClient.invalidateQueries({ queryKey: ['vehicle-usage', user?.id] });
       toast({
         title: 'Sucesso!',
         description: 'Registro de uso criado com sucesso.',
@@ -151,7 +151,7 @@ export const useVehicleUsage = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicle-usage'] });
+      queryClient.invalidateQueries({ queryKey: ['vehicle-usage', user?.id] });
       toast({
         title: 'Sucesso!',
         description: 'Registro de uso atualizado com sucesso.',
@@ -180,7 +180,7 @@ export const useVehicleUsage = () => {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicle-usage'] });
+      queryClient.invalidateQueries({ queryKey: ['vehicle-usage', user?.id] });
       toast({
         title: 'Sucesso!',
         description: 'Registro de uso deletado com sucesso.',

--- a/src/hooks/useVehicles.tsx
+++ b/src/hooks/useVehicles.tsx
@@ -48,7 +48,7 @@ export const useVehicles = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicles'] });
+      queryClient.invalidateQueries({ queryKey: ['vehicles', user?.id] });
       toast({
         title: "Veículo criado!",
         description: "Seu veículo foi cadastrado com sucesso.",
@@ -76,7 +76,7 @@ export const useVehicles = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicles'] });
+      queryClient.invalidateQueries({ queryKey: ['vehicles', user?.id] });
       toast({
         title: "Veículo atualizado!",
         description: "As informações foram salvas com sucesso.",
@@ -101,7 +101,7 @@ export const useVehicles = () => {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicles'] });
+      queryClient.invalidateQueries({ queryKey: ['vehicles', user?.id] });
       toast({
         title: "Veículo removido!",
         description: "O veículo foi excluído com sucesso.",


### PR DESCRIPTION
## Summary
- use user ID in invalidateQueries calls so React Query refreshes data properly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ee2b55d08325b483de32b7cb4242