### PR TITLE
Add vitest and basic calculation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,6 +80,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/components/RefuelingForm.tsx
+++ b/src/components/RefuelingForm.tsx
@@ -19,6 +19,10 @@ interface RefuelingFormProps {
   isLoading?: boolean;
 }
 
+export const calculateTotal = (liters: number, pricePerLiter: number) => {
+  return (liters * pricePerLiter).toFixed(2);
+};
+
 export const RefuelingForm = ({ isOpen, onOpenChange, onSubmit, refueling, isLoading }: RefuelingFormProps) => {
   const { vehicles } = useVehicles();
   const [formData, setFormData] = useState({
@@ -54,9 +58,6 @@ export const RefuelingForm = ({ isOpen, onOpenChange, onSubmit, refueling, isLoa
     }
   };
 
-  const calculateTotal = (liters: number, pricePerLiter: number) => {
-    return (liters * pricePerLiter).toFixed(2);
-  };
 
   const handleLitersChange = (value: string) => {
     const liters = Number(value);

--- a/src/components/__tests__/refueling-form.test.ts
+++ b/src/components/__tests__/refueling-form.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { calculateTotal } from '../RefuelingForm';
+
+describe('calculateTotal', () => {
+  it('returns correct total for liters and price', () => {
+    expect(calculateTotal(10, 5)).toBe('50.00');
+  });
+});


### PR DESCRIPTION
## Summary
- expose `calculateTotal` helper
- add initial vitest unit test
- include vitest in devDependencies and npm test script

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f04a3a1c83259d6e06f67881abd8